### PR TITLE
Update class and add new extension method in Microsoft.Identity.Client namespace

### DIFF
--- a/src/client/Microsoft.Identity.Client/Extensibility/AbstractConfidentialClientAcquireTokenParameterBuilderExtension.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/AbstractConfidentialClientAcquireTokenParameterBuilderExtension.cs
@@ -7,10 +7,11 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Identity.Client.Extensibility
 {
+
     /// <summary>
     /// Extensions for all AcquireToken methods
     /// </summary>
-    public static partial class AbstractConfidentialClientAcquireTokenParameterBuilderExtension
+    public static class AbstractConfidentialClientAcquireTokenParameterBuilderExtension
     {
         /// <summary>
         /// Intervenes in the request pipeline, by executing a user provided delegate before MSAL makes the token request. 

--- a/src/client/Microsoft.Identity.Client/Extensibility/AcquireTokenForClientBuilderExtensions.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/AcquireTokenForClientBuilderExtensions.cs
@@ -2,9 +2,13 @@
 // Licensed under the MIT License.
 
 using System;
+using System.ComponentModel;
 
 namespace Microsoft.Identity.Client.Extensibility
 {
+    /// <summary>
+    /// 
+    /// </summary>
     public static class AcquireTokenForClientBuilderExtensions
     {
         /// <summary>

--- a/src/client/Microsoft.Identity.Client/Extensibility/AcquireTokenForClientBuilderExtensions.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/AcquireTokenForClientBuilderExtensions.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Microsoft.Identity.Client.Extensibility
+{
+    public static class AcquireTokenForClientBuilderExtensions
+    {
+        /// <summary>
+        /// Binds the token to a key in the cache. L2 cache keys contain the key id.
+        /// No cryptographic operations is performed on the token.
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="keyId">A key id to which the access token is associated. The token will not be retrieved from the cache unless the same key id is presented. Can be null.</param>
+        /// <param name="expectedTokenTypeFromAad">AAD issues several types of bound tokens. MSAL checks the token type, which needs to match the value set by ESTS. Normal POP tokens have this as "pop"</param>
+        /// <returns>the builder</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)] // https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/4789        
+        public static AcquireTokenForClientParameterBuilder WithProofOfPosessionKeyId( 
+            this AcquireTokenForClientParameterBuilder builder,
+            string keyId,
+            string expectedTokenTypeFromAad = "Bearer")
+        {
+            if (string.IsNullOrEmpty(keyId))
+            {
+                throw new ArgumentNullException(nameof(keyId));
+            }
+
+            builder.ValidateUseOfExperimentalFeature();
+            builder.CommonParameters.AuthenticationScheme = new ExternalBoundTokenScheme(keyId, expectedTokenTypeFromAad);
+
+            return builder;
+        }
+    }
+}


### PR DESCRIPTION
### **User description**
Fixes #
<!-- Add the issue number above. If this PR only partially fixes the issue, remove the Fixes word above so that the issue is not automatically closed. -->

**Changes proposed in this request**
<!-- Concisely list the changes. -->
<!-- If helpful, describe how and why the bug was fixed. -->
<!-- If needed, describe how to review (ex. which files have the primary changes, which are nit changes, etc.) -->

**Testing**
<!-- Have unit, integration, etc. tests been added? Describe any relevant testing that has been done. -->
<!-- Mention if any and what extra manual testing is needed during the release. -->

**Performance impact**
<!-- Describe any applicable performance impact or performance testing done. -->

**Documentation**
- [ ] All relevant documentation is updated.


___

### **Description**
- Update `AbstractConfidentialClientAcquireTokenParameterBuilderExtension` class by removing the `partial` keyword
- Add a new extension method `WithProofOfPosessionKeyId` to the `AcquireTokenForClientBuilderExtensions` class


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AbstractConfidentialClientAcquireTokenParameterBuilderExtension.cs</strong><dd><code>Update class by removing `partial` keyword</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/client/Microsoft.Identity.Client/Extensibility/AbstractConfidentialClientAcquireTokenParameterBuilderExtension.cs
['Updated `AbstractConfidentialClientAcquireTokenParameterBuilderExtension` class to remove `partial` keyword']


</details>


  </td>
  <td><a href="https://github.com/2lambda123/-AzureAD-microsoft-authentication-library-for-dotnet/pull/1/files#diff-efa24ab5d459e31957b63e0ebb2a6ac27bdaaea09ad2779e3056462a71028373">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>AcquireTokenForClientBuilderExtensions.cs</strong><dd><code>Add new extension method for proof of possession key ID</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/client/Microsoft.Identity.Client/Extensibility/AcquireTokenForClientBuilderExtensions.cs
['Added a new extension method `WithProofOfPosessionKeyId` to `AcquireTokenForClientBuilderExtensions` class']


</details>


  </td>
  <td><a href="https://github.com/2lambda123/-AzureAD-microsoft-authentication-library-for-dotnet/pull/1/files#diff-8b915cde90a707c1d743796698d3aff57bb3980647d6def2622c9b6c214aa2f8">+39/-0</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new method to bind tokens to a cache key and set authentication schemes for enhanced security and token management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->